### PR TITLE
Update CI to Node 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [22]
 
     steps:
     - uses: actions/checkout@v2
@@ -24,7 +24,7 @@ jobs:
     - run: npm install
     - run: npm test
     - run: cd examples/biomemap/ && npm install
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: public
         path: examples/biomemap/public/*


### PR DESCRIPTION
## Summary
- Update CI node version matrix to Node 22
- Drop support for EOL Node versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)